### PR TITLE
Fix card heights with object-fit

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -115,11 +115,13 @@ body {
     overflow: hidden;
     box-shadow: 0 4px 6px rgba(0,0,0,0.1);
     display: inline-block;
+    height: 250px;
 }
 .image-card img {
     display: block;
     width: 100%;
-    height: auto;
+    height: 100%;
+    object-fit: cover;
 }
 .image-card .top-caption {
     position: absolute;


### PR DESCRIPTION
## Summary
- force `.image-card` containers to a fixed height
- ensure images fill cards and maintain cover with `object-fit`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f99d1ab448329941f8f5ae051c599