### PR TITLE
Fix flipbook demo without external jQuery

### DIFF
--- a/fliptest.html
+++ b/fliptest.html
@@ -3,23 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="scripts/turn.min.js"></script>
+  <link rel="stylesheet" href="styles/flipbook.css">
+  <script src="scripts/flipbook.js"></script>
 </head>
 <body>
-<div id="flipbook">
-  <div> Page 1 </div>
-  <div> Page 2 </div>
-  <div> Page 3 </div>
-  <div> Page 4 </div>
+<div class="book" id="flipbook">
+  <div class="page">Page 1</div>
+  <div class="page">Page 2</div>
+  <div class="page">Page 3</div>
+  <div class="page">Page 4</div>
 </div>
-
-<script type="text/javascript">
-  $("#flipbook").turn({
-    width: 400,
-    height: 300,
-    autoCenter: true
-  });
-</script>
 </body>
 </html>

--- a/scripts/flipbook.js
+++ b/scripts/flipbook.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const pages = document.querySelectorAll('.book .page');
+  let current = 0;
+
+  pages.forEach((page, index) => {
+    page.style.zIndex = pages.length - index;
+    page.addEventListener('click', () => {
+      if (index === current) {
+        page.classList.add('flipped');
+        current = Math.min(current + 1, pages.length - 1);
+      } else if (index === current - 1) {
+        page.classList.remove('flipped');
+        current = Math.max(current - 1, 0);
+      }
+    });
+  });
+});
+

--- a/styles/flipbook.css
+++ b/styles/flipbook.css
@@ -1,0 +1,28 @@
+.book {
+  width: 400px;
+  height: 300px;
+  position: relative;
+  perspective: 1000px;
+}
+.page {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  background: #4d4634;
+  color: white;
+  border: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backface-visibility: hidden;
+  transform-origin: left;
+  transition: transform 0.6s;
+}
+.page:nth-child(even) {
+  background: #6a653a;
+}
+.page.flipped {
+  transform: rotateY(-180deg);
+}


### PR DESCRIPTION
## Summary
- remove CDN jQuery dependency
- replace turn.js usage with simple vanilla JS flip implementation
- add minimal CSS and JS for page flipping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b5546c0ac832991b0933d5eb87c2e